### PR TITLE
(2-1)中級 ログイン者名表示 機能の改善

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -113,6 +113,7 @@ public class AdministratorController {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return toLogin();
 		}
+		model.addAttribute("administratorName", administrator.getName());
 		return "forward:/employee/showList";
 	}
 	


### PR DESCRIPTION
ログイン後に「～～さんこんにちは」の「～～」の部分にログイン管理者の名前が表示されるように改善しました。

問題があればコメントを頂ければと思います。
特に問題がなければマージをお願い致します。
