### PR TITLE
(2-1)中級 ログイン者名表示　機能の改善

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -107,13 +107,13 @@ public class AdministratorController {
 	 * @return ログイン後の従業員一覧画面
 	 */
 	@RequestMapping("/login")
-	public String login(LoginForm form, BindingResult result, Model model) {
+	public String login(LoginForm form, BindingResult result,HttpSession session, Model model) {
 		Administrator administrator = administratorService.login(form.getMailAddress(), form.getPassword());
 		if (administrator == null) {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return toLogin();
 		}
-		model.addAttribute("administratorName", administrator.getName());
+		session.setAttribute("administratorName", administrator.getName());
 		return "forward:/employee/showList";
 	}
 	

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -113,6 +113,7 @@ public class AdministratorController {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return toLogin();
 		}
+		model.addAttribute("administratorName", administrator.getName());
 		return "forward:/employee/showList";
 	}
 	

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -40,7 +40,7 @@
 						<li class="active"><a href="list.html" th:href="@{/employee/showList}">従業員管理</a></li>
 					</ul>
 					<p class="navbar-text navbar-right">
-					   <span th:text="${administratorName}">山田太郎</span>さんこんにちは！
+					   <span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！
 						&nbsp;&nbsp;&nbsp;
 						<a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
 					</p>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -40,7 +40,7 @@
 						<li class="active"><a href="list.html" th:href="@{/employee/showList}">従業員管理</a></li>
 					</ul>
 					<p class="navbar-text navbar-right">
-						<span th:text="${administratorName}">山田太郎</span>さんこんにちは！
+						<span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！
 						&nbsp;&nbsp;&nbsp;
 						<a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
 					</p>


### PR DESCRIPTION
ログイン後に「～～さんこんにちは」の「～～」の部分にログイン管理者の名前が表示されるように改善しました。
格納するスコープをセッションスコープに変更したのですが、正しいか少し不安です。

問題があればコメントを頂ければと思います。
特に問題がなければマージをお願い致します。